### PR TITLE
Fix LSP workspace/configuration response

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,14 @@ lsp-mode client leveraging [Pyright language server](https://github.com/microsof
 
 - `pyright.disableLanguageServices` via `lsp-pyright-disable-language-services`
 - `pyright.disableOrganizeImports` via `lsp-pyright-disable-organize-imports`
+- `python.analysis.autoImportCompletions` via `lsp-pyright-auto-import-completions`
 - `python.analysis.useLibraryCodeForTypes` via `lsp-pyright-use-library-code-for-types`
+- `python.analysis.typeshedPaths` via `lsp-pyright-typeshed-paths`
 - `python.analysis.diagnosticMode` via `lsp-pyright-diagnostic-mode`
 - `python.analysis.typeCheckingMode` via `lsp-pyright-typechecking-mode`
 - `python.analysis.logLevel` via `lsp-pyright-log-level`
 - `python.analysis.autoSearchPaths` via `lsp-pyright-auto-search-paths`
 - `python.analysis.extraPaths` via `lsp-pyright-extra-paths`
+- `python.venvPath` via `lsp-pyright-venv-path`
 
 Projects can be further configured using `prightconfig.json` file. For further details please see [Pyright Configuration](https://github.com/microsoft/pyright/blob/master/docs/configuration.md).

--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -203,16 +203,6 @@ Current LSP WORKSPACE should be passed in."
                 '(:npm :package "pyright"
                        :path "pyright-langserver"))
 
-;; It additionally handles cases such as section is nested path. i.e: "python.analysis"
-(lsp-defun lsp-pyright--workspace-configuration (_workspace (&ConfigurationParams :items))
-  "Get section configuration.
-PARAMS are the `workspace/configuration' request params"
-  (->> items
-       (-map (-lambda ((&ConfigurationItem :section?))
-               (apply 'ht-get* (append (list (lsp-configuration-section section?))
-                                       (split-string section? "\\.")))))
-       (apply #'vector)))
-
 (lsp-register-client
  (make-lsp-client
   :new-connection (lsp-stdio-connection (lambda ()
@@ -228,7 +218,6 @@ PARAMS are the `workspace/configuration' request params"
                       ;; configuration of each workspace folder later separately
                       (lsp--set-configuration
                        (make-hash-table :test 'equal))))
-  :request-handlers (lsp-ht ("workspace/configuration" 'lsp-pyright--workspace-configuration))
   :download-server-fn (lambda (_client callback error-callback _update?)
                         (lsp-package-ensure 'pyright callback error-callback))
   :notification-handlers (lsp-ht ("pyright/beginProgress" 'lsp-pyright--begin-progress-callback)


### PR DESCRIPTION
As reported in #7 users can't get completions for `numpy` even if the correct python environment is selected and `useLibraryCodeForTypes` is enabled. This PR fixes this issue.

- Pyright Logs should a `TypeError cannot call replace of undefined`. It was due to `python.venvPath` being undefined, unfortunately it caused parsing error and the rest of the configuration (such as `useLibraryCodeForTypes`) was not read by the server and ignored.
  - @seagle0128 added `python.venvPath` in #9, however due to my misunderstanding it was removed. (the `venv` names should be fixed and specified in `pyrightconfig.json` for each project, however users `venvPath` will differ; thus it is better to leave `venvPath` unspecified in `pyrightconfig.json` and leave to the user's config)
    - source: https://github.com/microsoft/pyright/issues/30#issuecomment-478037973.
- Pyright Language server asks for `workspace/configuration` for `python.analysis` which current `lsp-mode`'s implementation cannot handle (nested path). We override `workspace/configuration` handler to be able to answer this requests. (maybe it is better to merge this part to `lsp-mode`).
  - Current lsp-mode implementation: https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-mode.el#L5496
- Added some few new configs (not directly related to this PR, just bike-shedding to this PR)
  - `typeshedPaths`
  - `stubPath`
  - `autoImportCompletions`
- Set default value of `useLibraryCodeForTypes` to `true` (same as `pylance`)
