### PR TITLE
Show progress spinner conditionally on `lsp-progress-via-spinner`

### DIFF
--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -167,11 +167,13 @@ Only available in Emacs 27 and above."
 (defun lsp-pyright--begin-progress-callback (workspace &rest _)
   "Log begin progress information.
 Current LSP WORKSPACE should be passed in."
-  (with-lsp-workspace workspace
-    (--each (lsp--workspace-buffers workspace)
-      (when (buffer-live-p it)
-        (with-current-buffer it
-          (lsp--spinner-start)))))
+  (when lsp-progress-via-spinner
+    (with-lsp-workspace workspace
+      (--each (lsp--workspace-buffers workspace)
+	(when (buffer-live-p it)
+          (with-current-buffer it
+            (lsp--spinner-start)))))
+    )
   (lsp--info "Pyright language server is analyzing..."))
 
 (defun lsp-pyright--report-progress-callback (_workspace params)
@@ -183,12 +185,14 @@ First element of PARAMS will be passed into `lsp-log'."
 (defun lsp-pyright--end-progress-callback (workspace &rest _)
   "Log end progress information.
 Current LSP WORKSPACE should be passed in."
-  (with-lsp-workspace workspace
-    (--each (lsp--workspace-buffers workspace)
-      (when (buffer-live-p it)
-        (with-current-buffer it
-          (lsp--spinner-stop))))
-    (lsp--info "Pyright language server is analyzing...done")))
+  (when lsp-progress-via-spinner
+    (with-lsp-workspace workspace
+      (--each (lsp--workspace-buffers workspace)
+	(when (buffer-live-p it)
+          (with-current-buffer it
+            (lsp--spinner-stop)))))
+    )
+  (lsp--info "Pyright language server is analyzing...done"))
 
 (lsp-register-custom-settings
  `(("pyright.disableLanguageServices" lsp-pyright-disable-language-services t)


### PR DESCRIPTION
The current code does not check the value of boolean variable `lsp-progress-via-spinner` ([defined in lsp-mode](https://github.com/emacs-lsp/lsp-mode/blob/fb4c35c6978415c4cf52f85230b527d311989063/lsp-mode.el#L363)) when showing a spinner to indicate that "analysis is in progress". This means that the user cannot use that variable to disable the spinner when using `lsp-pyright`.

I personally have found the spinner to be distracting, since analysis can activate quite often. This code simply adds a conditional check on the value of `lsp-progress-via-spinner`, and does not show the spinner if the value is `nil`.