### PR TITLE
Add new variable `lsp-pyright-show-analyzing` to control minibuffer printouts

### DIFF
--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -167,11 +167,13 @@ Only available in Emacs 27 and above."
 (defun lsp-pyright--begin-progress-callback (workspace &rest _)
   "Log begin progress information.
 Current LSP WORKSPACE should be passed in."
-  (with-lsp-workspace workspace
-    (--each (lsp--workspace-buffers workspace)
-      (when (buffer-live-p it)
-        (with-current-buffer it
-          (lsp--spinner-start)))))
+  (when lsp-progress-via-spinner
+    (with-lsp-workspace workspace
+      (--each (lsp--workspace-buffers workspace)
+	(when (buffer-live-p it)
+          (with-current-buffer it
+            (lsp--spinner-start)))))
+    )
   (lsp--info "Pyright language server is analyzing..."))
 
 (defun lsp-pyright--report-progress-callback (_workspace params)
@@ -183,12 +185,14 @@ First element of PARAMS will be passed into `lsp-log'."
 (defun lsp-pyright--end-progress-callback (workspace &rest _)
   "Log end progress information.
 Current LSP WORKSPACE should be passed in."
-  (with-lsp-workspace workspace
-    (--each (lsp--workspace-buffers workspace)
-      (when (buffer-live-p it)
-        (with-current-buffer it
-          (lsp--spinner-stop))))
-    (lsp--info "Pyright language server is analyzing...done")))
+  (when lsp-progress-via-spinner
+    (with-lsp-workspace workspace
+      (--each (lsp--workspace-buffers workspace)
+	(when (buffer-live-p it)
+          (with-current-buffer it
+            (lsp--spinner-stop)))))
+    )
+  (lsp--info "Pyright language server is analyzing...done"))
 
 (lsp-register-custom-settings
  `(("pyright.disableLanguageServices" lsp-pyright-disable-language-services t)

--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -149,6 +149,11 @@ Only available in Emacs 27 and above."
   :type 'boolean
   :group 'lsp-pyright)
 
+(defcustom lsp-pyright-show-analyzing t
+  "If non nil, lsp-pyright will notify in the minibuffer that it is running analysis."
+  :type 'boolean
+  :group 'lsp-pyright)
+
 (defun lsp-pyright-locate-venv ()
   "Look for virtual environments local to the workspace."
   (or lsp-pyright-venv-path
@@ -174,7 +179,8 @@ Current LSP WORKSPACE should be passed in."
           (with-current-buffer it
             (lsp--spinner-start)))))
     )
-  (lsp--info "Pyright language server is analyzing..."))
+  (when lsp-pyright-show-analyzing
+    (lsp--info "Pyright language server is analyzing...")))
 
 (defun lsp-pyright--report-progress-callback (_workspace params)
   "Log report progress information.
@@ -192,7 +198,8 @@ Current LSP WORKSPACE should be passed in."
           (with-current-buffer it
             (lsp--spinner-stop)))))
     )
-  (lsp--info "Pyright language server is analyzing...done"))
+  (when lsp-pyright-show-analyzing
+    (lsp--info "Pyright language server is analyzing...done")))
 
 (lsp-register-custom-settings
  `(("pyright.disableLanguageServices" lsp-pyright-disable-language-services t)


### PR DESCRIPTION
`lsp-pyright` currently prints `Pyright language server is analyzing...` and `Pyright language server is analyzing...done` when analysis is run on the source code. However, the analysis can be triggered quite often by `lsp-mode`, and it is distracting if the above strings are constantly printed to the minibuffer.

The new variable `lsp-pyright-show-analyzing` allows the user to control this behavior. By setting this variable to `nil`, the above minibuffer printouts are suppressed. The default value is `t`, so the default behavior is the same as in the current implementation (the minibuffer messages are printed).