### PR TITLE
[WIP] Add support for detecting venvs from pipenv and poetry projects

### DIFF
--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -156,6 +156,9 @@ Only available in Emacs 27 and above."
   :type 'list
   :group 'lsp-pyright)
 
+(defvar lsp-pyright--project-info-cache nil
+  "Used to cache results from project management tools between invocations.")
+
 (defun lsp-pyright--locate-pipenv ()
   "Get the path of the pipenv executable. If
   `lsp-pyright-pipenv-executable-cmd' is non-nil it will be
@@ -202,8 +205,7 @@ CMD does not return a failure status."
   "Queries poetry or pipenv for project information and returns
 either the virtualenv or the python interpreter of the project
 depending on whether the value of PROPERTY is 'python or 'venv."
-  (unless (and (boundp 'lsp-pyright--project-info-cache)
-               lsp-pyright--project-info-cache)
+  (unless lsp-pyright--project-info-cache
     (setq-local
      lsp-pyright--project-info-cache
      (let ((project-info


### PR DESCRIPTION
This PR adds support for detecting if a project is managed using either poetry or pipenv and configuring pyright to use the venv and python interpreter created by those tools.

I have been using this code for a while without problems and I think it's extremely useful. However, there are a couple of problems with the code, thus the WIP tag:
 - The synchronous subprocess invocation causes emacs to freeze briefly when opening a file from a python project for the first time. Is there a way to do this asynchronously?
 - The code currently detects a `pipenv` project if `Pipfile` exists in the project root and `pipenv` is found in `PATH`. Likewise, poetry is assumed if `pyproject.toml` is found in the project root and `poetry` is found in `PATH`. This naive approach misses several obvious cases, but I wonder if there is a method or even need to make the detection mechanism more accurate or if it's better to add a customization variable that overrides the detection?

I'm looking forward to your feedback!