### PR TITLE
Activate lsp-pyright only when config file found

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,12 @@ lsp-mode client leveraging [Pyright language server](https://github.com/microsof
 - `python.venvPath` via `lsp-pyright-venv-path`
 
 Projects can be further configured using `pyrightconfig.json` file. For further details please see [Pyright Configuration](https://github.com/microsoft/pyright/blob/master/docs/configuration.md).
+
+### FAQ
+
+#### Why don't I see a `pyright` server running in my project when I `M-x lsp-describe-session`?
+
+`lsp-pyright` is only activated when
+[configurated](https://github.com/microsoft/pyright/blob/master/docs/configuration.md)
+properly. So you either need to write a `pyrightconfig.json` file or a
+`[tool.pyright]` section your project's `pyproject.toml` file.

--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -231,10 +231,18 @@ Current LSP WORKSPACE should be passed in."
   :new-connection (lsp-stdio-connection (lambda ()
                                           (cons (lsp-package-path 'pyright)
                                                 lsp-pyright-langserver-command-args)))
-  :major-modes '(python-mode)
   :server-id 'pyright
   :multi-root lsp-pyright-multi-root
   :priority 3
+  :activation-fn (lambda (file-name mode)
+                   (and (or (not (null (string-match-p "py[iw]?" (file-name-extension file-name))))
+                            (eq mode 'python-mode))
+                        (or (locate-dominating-file file-name "pyrightconfig.json")
+                            (when-let ((pep518-config-file-dir (locate-dominating-file file-name "pyproject.toml")))
+                              (with-temp-buffer
+                                (insert-file-contents (concat pep518-config-file-dir "pyproject.toml"))
+                                (goto-char (point-min))
+                                (search-forward "[tool.pyright]" nil t nil))))))
   :initialized-fn (lambda (workspace)
                     (with-lsp-workspace workspace
                       ;; we send empty settings initially, LSP server will ask for the

--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -235,7 +235,7 @@ Current LSP WORKSPACE should be passed in."
   :multi-root lsp-pyright-multi-root
   :priority 3
   :activation-fn (lambda (file-name mode)
-                   (and (or (not (null (string-match-p "py[iw]?" (file-name-extension file-name))))
+                   (and (or (not (null (string-match-p "py[iw]?" (or (file-name-extension file-name) ""))))
                             (eq mode 'python-mode))
                         (or (locate-dominating-file file-name "pyrightconfig.json")
                             (when-let ((pep518-config-file-dir (locate-dominating-file file-name "pyproject.toml")))


### PR DESCRIPTION
lsp-pyright should not be activated unless a config file is located﻿
