### PR TITLE
Fix minor typo, correcting "perfer" to "prefer"

### DIFF
--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -151,7 +151,7 @@ set as `python3' to let ms-pyls use python 3 environments."
   :group 'lsp-pyright)
 
 (defcustom lsp-pyright-prefer-remote-env t
-  "If non nil, lsp-pyright will perfer remote python environment.
+  "If non nil, lsp-pyright will prefer remote python environment.
 Only available in Emacs 27 and above."
   :type 'boolean
   :group 'lsp-pyright)


### PR DESCRIPTION
The docstring for `lsp-pyright-prefer-remote-env` begins "If non nil, lsp-pyright will perfer remote python environment." This simply corrects "perfer" to "prefer".