### PR TITLE
Provide a way to change how the python executable is found

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ lsp-mode client leveraging [Pyright language server](https://github.com/microsof
 Projects can be further configured using `pyrightconfig.json` file. For further details please see
 [Pyright Configuration](https://github.com/microsoft/pyright/blob/master/docs/configuration.md).
 
+## Choosing the correct version of Python
+
+`lsp-pyright` will try its best to select the correct version of the
+python executable to use. It will do so by iteratively executing
+different search functions, going from most precise to most
+general.
+
+The list and order of the list can be modified by customizing
+`lsp-pyright-python-search-functions`. By default the order is:
+ - Look for a parent directory with a virtual-environment named
+   `.venv` or `venv` via `lsp-pyright--locate-python-venv`.
+ - Look for a python executable on your PATH via
+   `lsp-pyright--locate-python-python`.
+
 ## Usage notes
 
 Pyright includes a recent copy of the Python stdlib type stubs. To add type stubs for additional


### PR DESCRIPTION
## Problem

I've found it difficult to change which version of Python is in
use. Right now it defaults to finding a parent .venv but I would
rather it default to using the `python` executable that I've set.

## Solution

To maintain backwards compatibility I've modified
`lsp-pyright-locate-python` to support a new list of "locating"
functions. These functions each return a `python` executable or `nil`
when the search method fails. The order of functions defaults to what
existed beforehand but now it is possible to `customize` that order by
modifying `lsp-pyright-python-search-functions`.

## Testing

I've tested the default configuration. It returned the cursed configuration that I did not want.

I also tested with
```emacs-lisp
(setq lsp-pyright-python-search-functions
  '(lsp-pyright--locate-python-python))
```
which is what I've been using and intend on using