### PR TITLE
remove settings that can be overridden by config files

### DIFF
--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -56,14 +56,6 @@
   :type 'boolean
   :group 'lsp-pyright)
 
-(defcustom lsp-pyright-use-library-code-for-types t
-  "Determines whether to analyze library code.
-In order to extract type information in the absence of type stub files.
-This can add significant overhead and may result in
-poor-quality type information.
-The default value for this option is true."
-  :type 'boolean
-  :group 'lsp-pyright)
 
 (defcustom lsp-pyright-diagnostic-mode "openFilesOnly"
   "Determines pyright diagnostic mode.
@@ -73,15 +65,6 @@ If this option is set to \"openFilesOnly\", pyright analyzes only open files."
   :type '(choice
           (const "openFilesOnly")
           (const "workspace"))
-  :group 'lsp-pyright)
-
-(defcustom lsp-pyright-typechecking-mode "basic"
-  "Determines the default type-checking level used by pyright.
-This can be overridden in the configuration file."
-  :type '(choice
-          (const "off")
-          (const "basic")
-          (const "strict"))
   :group 'lsp-pyright)
 
 (defcustom lsp-pyright-log-level "info"
@@ -230,9 +213,7 @@ Current LSP WORKSPACE should be passed in."
    ("python.analysis.autoImportCompletions" lsp-pyright-auto-import-completions t)
    ("python.analysis.typeshedPaths" lsp-pyright-typeshed-paths)
    ("python.analysis.stubPath" lsp-pyright-stub-path)
-   ("python.analysis.useLibraryCodeForTypes" lsp-pyright-use-library-code-for-types t)
    ("python.analysis.diagnosticMode" lsp-pyright-diagnostic-mode)
-   ("python.analysis.typeCheckingMode" lsp-pyright-typechecking-mode)
    ("python.analysis.logLevel" lsp-pyright-log-level)
    ("python.analysis.autoSearchPaths" lsp-pyright-auto-search-paths t)
    ("python.analysis.extraPaths" lsp-pyright-extra-paths)


### PR DESCRIPTION
`python.analysis.useLibraryCodeForTypes` and `python.analysis.typeCheckingMode` can be overridden by config files, setting them by default globally overrides all projects and the user's intention. Given all other settings that can appear in config files does not have a defcustom, it makes sense to remove them as well.