### PR TITLE
Adds support for the basedpyright pyright fork

### DIFF
--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -62,7 +62,7 @@
   :type 'boolean
   :group 'lsp-pyright)
 
-(defcustom lsp-pyright-diagnostic-mode "openFilesOnly"
+(defcustom lsp-pyright-diagnostic-mode "workspace"
   "Determines pyright diagnostic mode.
 Whether pyright analyzes (and reports errors for) all files
 in the workspace, as indicated by the config file.

--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 emacs-lsp maintainers
 
 ;; Author: Arif Rezai, Vincent Zhang, Andrew Christianson
-;; Version: 0.2.1
+;; Version: 0.2.0
 ;; Package-Requires: ((emacs "26.1") (lsp-mode "7.0") (dash "2.18.0") (ht "2.0"))
 ;; Homepage: https://github.com/emacs-lsp/lsp-pyright
 ;; Keywords: languages, tools, lsp

--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -215,7 +215,7 @@ Current LSP WORKSPACE should be passed in."
    ("python.venvPath" (lambda () (or lsp-pyright-venv-path "")))))
 
 (lsp-dependency 'pyright
-                '(:system "basedpyright-langserver")
+                '(:system "basedpyright-langserver"))
 
 (lsp-register-client
  (make-lsp-client

--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -209,9 +209,9 @@ Current LSP WORKSPACE should be passed in."
                             (vector (concat "file://" (buffer-file-name)))))
 
 (lsp-register-custom-settings
- `((concat(lsp-pyright-fork ".disableLanguageServices") lsp-pyright-disable-language-services t)
-   (concat(lsp-pyright-fork ".disableOrganizeImports") lsp-pyright-disable-organize-imports t)
-   (concat(lsp-pyright-fork ".disableTaggedHints") lsp-pyright-disable-tagged-hints t)
+ `(((concat lsp-pyright-fork ".disableLanguageServices") lsp-pyright-disable-language-services t)
+   ((concat lsp-pyright-fork ".disableOrganizeImports") lsp-pyright-disable-organize-imports t)
+   ((concat lsp-pyright-fork ".disableTaggedHints") lsp-pyright-disable-tagged-hints t)
    ("python.analysis.autoImportCompletions" lsp-pyright-auto-import-completions t)
    ("python.analysis.diagnosticMode" lsp-pyright-diagnostic-mode)
    ("python.analysis.logLevel" lsp-pyright-log-level)

--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -209,9 +209,9 @@ Current LSP WORKSPACE should be passed in."
                             (vector (concat "file://" (buffer-file-name)))))
 
 (lsp-register-custom-settings
- `(((concat lsp-pyright-fork ".disableLanguageServices") lsp-pyright-disable-language-services t)
-   ((concat lsp-pyright-fork ".disableOrganizeImports") lsp-pyright-disable-organize-imports t)
-   ((concat lsp-pyright-fork ".disableTaggedHints") lsp-pyright-disable-tagged-hints t)
+ `((,(concat lsp-pyright-fork ".disableLanguageServices") lsp-pyright-disable-language-services t)
+   (,(concat lsp-pyright-fork ".disableOrganizeImports") lsp-pyright-disable-organize-imports t)
+   (,(concat lsp-pyright-fork ".disableTaggedHints") lsp-pyright-disable-tagged-hints t)
    ("python.analysis.autoImportCompletions" lsp-pyright-auto-import-completions t)
    ("python.analysis.diagnosticMode" lsp-pyright-diagnostic-mode)
    ("python.analysis.logLevel" lsp-pyright-log-level)

--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -222,7 +222,7 @@ Current LSP WORKSPACE should be passed in."
    ("python.venvPath" (lambda () (or lsp-pyright-venv-path "")))))
 
 (lsp-dependency 'pyright
-                '(:system ,(concat lsp-pyright-fork "-langserver") ))
+                (backquote (:system ,(concat lsp-pyright-fork "-langserver"))))
 
 (lsp-register-client
  (make-lsp-client

--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -41,7 +41,7 @@
   :group 'lsp-mode
   :link '(url-link "https://github.com/microsoft/pyright"))
 
-(defcustom lsp-pyright-fork "pyright"
+(defcustom lsp-pyright-fork "basedpyright"
   "Choose whether to use Pyright or the BasedPyright fork."
   :type '(choice
           (const "pyright")
@@ -222,7 +222,7 @@ Current LSP WORKSPACE should be passed in."
    ("python.venvPath" (lambda () (or lsp-pyright-venv-path "")))))
 
 (lsp-dependency 'pyright
-                '(:system "basedpyright-langserver"))
+                '(:system ,(concat lsp-pyright-fork "-langserver") ))
 
 (lsp-register-client
  (make-lsp-client

--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -222,7 +222,7 @@ Current LSP WORKSPACE should be passed in."
    ("python.venvPath" (lambda () (or lsp-pyright-venv-path "")))))
 
 (lsp-dependency 'pyright
-                '(:system (concat lsp-pyright-fork "-langserver")))
+                '(:system "basedpyright-langserver"))
 
 (lsp-register-client
  (make-lsp-client

--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -222,7 +222,7 @@ Current LSP WORKSPACE should be passed in."
    ("python.venvPath" (lambda () (or lsp-pyright-venv-path "")))))
 
 (lsp-dependency 'pyright
-                '(:system concat(lsp-pyright-fork "-langserver")))
+                '(:system (concat lsp-pyright-fork "-langserver")))
 
 (lsp-register-client
  (make-lsp-client

--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -41,7 +41,7 @@
   :group 'lsp-mode
   :link '(url-link "https://github.com/microsoft/pyright"))
 
-(defcustom lsp-pyright-fork "basedpyright"
+(defcustom lsp-pyright-fork "pyright"
   "Choose whether to use Pyright or the BasedPyright fork."
   :type '(choice
           (const "pyright")

--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -205,7 +205,7 @@ Current LSP WORKSPACE should be passed in."
 (defun lsp-pyright-organize-imports ()
   "Organize imports in current buffer."
   (interactive)
-  (lsp-send-execute-command (concat(lsp-pyright-fork ".organizeimports"))
+  (lsp-send-execute-command (concat lsp-pyright-fork ".organizeimports")
                             (vector (concat "file://" (buffer-file-name)))))
 
 (lsp-register-custom-settings
@@ -222,7 +222,7 @@ Current LSP WORKSPACE should be passed in."
    ("python.venvPath" (lambda () (or lsp-pyright-venv-path "")))))
 
 (lsp-dependency 'pyright
-                '(:system concat(lsp-pyright-fork "-langserver"))
+                '(:system concat(lsp-pyright-fork "-langserver")))
 
 (lsp-register-client
  (make-lsp-client
@@ -241,15 +241,15 @@ Current LSP WORKSPACE should be passed in."
                        (make-hash-table :test 'equal))))
   :download-server-fn (lambda (_client callback error-callback _update?)
                         (lsp-package-ensure 'pyright callback error-callback))
-  :notification-handlers (lsp-ht (concat(lsp-pyright-fork "/beginProgress") 'lsp-pyright--begin-progress-callback)
-                                 (concat(lsp-pyright-fork "/reportProgress") 'lsp-pyright--report-progress-callback)
-                                 (concat(lsp-pyright-fork "/endProgress") 'lsp-pyright--end-progress-callback))))
+  :notification-handlers (lsp-ht ((concat lsp-pyright-fork "/beginProgress") 'lsp-pyright--begin-progress-callback)
+                                 ((concat lsp-pyright-fork "/reportProgress") 'lsp-pyright--report-progress-callback)
+                                 ((concat lsp-pyright-fork "/endProgress") 'lsp-pyright--end-progress-callback))))
 
 (lsp-register-client
  (make-lsp-client
   :new-connection
   (lsp-tramp-connection (lambda ()
-                          (cons (executable-find concat(lsp-pyright-fork "-langserver") t)
+                          (cons (executable-find (concat lsp-pyright-fork "-langserver") t)
                                 lsp-pyright-langserver-command-args)))
   :major-modes '(python-mode python-ts-mode)
   :server-id 'pyright-remote
@@ -262,9 +262,9 @@ Current LSP WORKSPACE should be passed in."
                       ;; configuration of each workspace folder later separately
                       (lsp--set-configuration
                        (make-hash-table :test 'equal))))
-  :notification-handlers (lsp-ht (concat(lsp-pyright-fork "/beginProgress") 'lsp-pyright--begin-progress-callback)
-                                 (concat(lsp-pyright-fork "/reportProgress") 'lsp-pyright--report-progress-callback)
-                                 (concat(lsp-pyright-fork "/endProgress") 'lsp-pyright--end-progress-callback))))
+  :notification-handlers (lsp-ht ((concat lsp-pyright-fork "/beginProgress") 'lsp-pyright--begin-progress-callback)
+                                 ((concat lsp-pyright-fork "/reportProgress") 'lsp-pyright--report-progress-callback)
+                                 ((concat lsp-pyright-fork "/endProgress") 'lsp-pyright--end-progress-callback))))
 
 (provide 'lsp-pyright)
 ;;; lsp-pyright.el ends here

--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -37,9 +37,9 @@
 
 ;; Group declaration
 (defgroup lsp-pyright nil
-  "LSP support for python using the Pyright Language Server."
+  "LSP support for python using the BasedPyright Language Server."
   :group 'lsp-mode
-  :link '(url-link "https://github.com/microsoft/pyright"))
+  :link '(url-link "https://github.com/DetachHead/basedpyright"))
 
 (defcustom lsp-pyright-langserver-command-args '("--stdio")
   "Command to start pyright-langserver."
@@ -176,7 +176,7 @@ Current LSP WORKSPACE should be passed in."
         (when (buffer-live-p it)
           (with-current-buffer it
             (lsp--spinner-start))))))
-  (lsp-log "Pyright language server is analyzing..."))
+  (lsp-log "BasedPyright language server is analyzing..."))
 
 (defun lsp-pyright--report-progress-callback (_workspace params)
   "Log report progress information.
@@ -193,18 +193,18 @@ Current LSP WORKSPACE should be passed in."
         (when (buffer-live-p it)
           (with-current-buffer it
             (lsp--spinner-stop))))))
-  (lsp-log "Pyright language server is analyzing...done"))
+  (lsp-log "BasedPyright language server is analyzing...done"))
 
 (defun lsp-pyright-organize-imports ()
   "Organize imports in current buffer."
   (interactive)
-  (lsp-send-execute-command "pyright.organizeimports"
+  (lsp-send-execute-command "basedpyright.organizeimports"
                             (vector (concat "file://" (buffer-file-name)))))
 
 (lsp-register-custom-settings
- `(("pyright.disableLanguageServices" lsp-pyright-disable-language-services t)
-   ("pyright.disableOrganizeImports" lsp-pyright-disable-organize-imports t)
-   ("pyright.disableTaggedHints" lsp-pyright-disable-tagged-hints t)
+ `(("basedpyright.disableLanguageServices" lsp-pyright-disable-language-services t)
+   ("basedpyright.disableOrganizeImports" lsp-pyright-disable-organize-imports t)
+   ("basedpyright.disableTaggedHints" lsp-pyright-disable-tagged-hints t)
    ("python.analysis.autoImportCompletions" lsp-pyright-auto-import-completions t)
    ("python.analysis.diagnosticMode" lsp-pyright-diagnostic-mode)
    ("python.analysis.logLevel" lsp-pyright-log-level)
@@ -215,9 +215,7 @@ Current LSP WORKSPACE should be passed in."
    ("python.venvPath" (lambda () (or lsp-pyright-venv-path "")))))
 
 (lsp-dependency 'pyright
-                '(:system "pyright-langserver")
-                '(:npm :package "pyright"
-                       :path "pyright-langserver"))
+                '(:system "basedpyright-langserver")
 
 (lsp-register-client
  (make-lsp-client
@@ -236,15 +234,15 @@ Current LSP WORKSPACE should be passed in."
                        (make-hash-table :test 'equal))))
   :download-server-fn (lambda (_client callback error-callback _update?)
                         (lsp-package-ensure 'pyright callback error-callback))
-  :notification-handlers (lsp-ht ("pyright/beginProgress" 'lsp-pyright--begin-progress-callback)
-                                 ("pyright/reportProgress" 'lsp-pyright--report-progress-callback)
-                                 ("pyright/endProgress" 'lsp-pyright--end-progress-callback))))
+  :notification-handlers (lsp-ht ("basedpyright/beginProgress" 'lsp-pyright--begin-progress-callback)
+                                 ("basedpyright/reportProgress" 'lsp-pyright--report-progress-callback)
+                                 ("basedpyright/endProgress" 'lsp-pyright--end-progress-callback))))
 
 (lsp-register-client
  (make-lsp-client
   :new-connection
   (lsp-tramp-connection (lambda ()
-                          (cons (executable-find "pyright-langserver" t)
+                          (cons (executable-find "basedpyright-langserver" t)
                                 lsp-pyright-langserver-command-args)))
   :major-modes '(python-mode python-ts-mode)
   :server-id 'pyright-remote
@@ -257,9 +255,9 @@ Current LSP WORKSPACE should be passed in."
                       ;; configuration of each workspace folder later separately
                       (lsp--set-configuration
                        (make-hash-table :test 'equal))))
-  :notification-handlers (lsp-ht ("pyright/beginProgress" 'lsp-pyright--begin-progress-callback)
-                                 ("pyright/reportProgress" 'lsp-pyright--report-progress-callback)
-                                 ("pyright/endProgress" 'lsp-pyright--end-progress-callback))))
+  :notification-handlers (lsp-ht ("basedpyright/beginProgress" 'lsp-pyright--begin-progress-callback)
+                                 ("basedpyright/reportProgress" 'lsp-pyright--report-progress-callback)
+                                 ("basedpyright/endProgress" 'lsp-pyright--end-progress-callback))))
 
 (provide 'lsp-pyright)
 ;;; lsp-pyright.el ends here

--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 emacs-lsp maintainers
 
 ;; Author: Arif Rezai, Vincent Zhang, Andrew Christianson
-;; Version: 0.2.0
+;; Version: 0.2.1
 ;; Package-Requires: ((emacs "26.1") (lsp-mode "7.0") (dash "2.18.0") (ht "2.0"))
 ;; Homepage: https://github.com/emacs-lsp/lsp-pyright
 ;; Keywords: languages, tools, lsp

--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -69,7 +69,7 @@
   :type 'boolean
   :group 'lsp-pyright)
 
-(defcustom lsp-pyright-diagnostic-mode "workspace"
+(defcustom lsp-pyright-diagnostic-mode "openFilesOnly"
   "Determines pyright diagnostic mode.
 Whether pyright analyzes (and reports errors for) all files
 in the workspace, as indicated by the config file.

--- a/lsp-pyright.el
+++ b/lsp-pyright.el
@@ -37,11 +37,12 @@
 
 ;; Group declaration
 (defgroup lsp-pyright nil
-  "LSP support for python using the BasedPyright Language Server."
+  "LSP support for python using the Pyright Language Server."
   :group 'lsp-mode
-  :link '(url-link "https://github.com/microsoft/pyright"))
+  :link '(url-link "https://github.com/microsoft/pyright")
+  :link '(url-link "https://github.com/DetachHead/basedpyright"))
 
-(defcustom lsp-pyright-fork "basedpyright"
+(defcustom lsp-pyright-fork "pyright"
   "Choose whether to use Pyright or the BasedPyright fork."
   :type '(choice
           (const "pyright")


### PR DESCRIPTION
This PR addresses issue: #92 

All commands that use "pyright/" are now instead created via concatenating the fork with the command. This can be customised with the lsp-pyright-fork customizable option.

use of "backquote" command instead of " ' " is because of an emacs-lisp bug please see: https://stackoverflow.com/questions/17394638/nesting-backquote-and-in-emacs-lisp and https://mail.gnu.org/archive/html/bug-gnu-emacs/2023-02/msg00617.html

All suggestions welcome, this is my first time contributing emacs-lisp code so I am not well versed with the standard practices :) 